### PR TITLE
fix: avoid INI special character issues

### DIFF
--- a/Monitoring/customizations/monitoring/grafana/esp-plugin/grafana-esp-plugin-main/install/v4m-grafana-config.template
+++ b/Monitoring/customizations/monitoring/grafana/esp-plugin/grafana-esp-plugin-main/install/v4m-grafana-config.template
@@ -57,7 +57,7 @@ data:
     use_pkce = true
     auto_login = true
     client_id = TEMPLATE_OAUTH_CLIENT_ID
-    client_secret = TEMPLATE_OAUTH_CLIENT_SECRET
+    client_secret = `TEMPLATE_OAUTH_CLIENT_SECRET`
     scopes = openid email profile
     email_attribute_path = email
     name_attribute_path = user_name


### PR DESCRIPTION
This PR encloses the `client_secret` Grafana configuration value in backticks to address INI parsing issues where some special characters are present in the secret value.